### PR TITLE
General half-integer Matérns and their embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ All multidimensional embeddings are based on product kernels and product measure
 | kernel / emdedding | `lebesgue` | `gaussian` |
 |--------------------|:----------:|:----------:|
 | `expquad`          |     x      |     x      |
+| `matern`           |     x      |            |
 | `matern12`         |     x      |     x      |
 | `matern32`         |     x      |     x      |
 | `matern52`         |     x      |            |
@@ -94,6 +95,16 @@ config_kernel = {
 ```
 
 where `ndim` = $d$ and `lengthscales` = $[\ell_1, ...\ell_d]$. 
+
+`matern` kernel of order $\nu = n + 1/2$ for $n \in \mathbb{N}_0$ with value $k(x_i, z_i) = \exp( -\sqrt{2n+1} r_i ) \frac{n!}{(2n)!} \sum_{k=0}^n \frac{(n+k)!}{k!(n-k)!} ( 2\sqrt{2n+1} \, r_i )^{n-k}$ where $r_i = \frac{|x_i - z_i|}{\ell_i}$.
+
+```python
+config_kernel = {
+    "ndim": 2,
+    "nu": 3.5,
+    "lengthscales": [1.0, 2.0],
+}
+```
 
 `matern12` with value $k(x_i, z_i) = e^{-r_i}$ where $r_i = \frac{|x_i - z_i|}{\ell_i}$.
 

--- a/kernel_embedding_dictionary/_get_embedding.py
+++ b/kernel_embedding_dictionary/_get_embedding.py
@@ -5,7 +5,7 @@
 from typing import Optional
 
 from .embeddings import KernelEmbedding
-from .kernels import ExpQuadKernel, Matern12Kernel, Matern32Kernel, Matern52Kernel, Matern72Kernel
+from .kernels import ExpQuadKernel, MaternKernel, Matern12Kernel, Matern32Kernel, Matern52Kernel, Matern72Kernel
 from .measures import GaussianMeasure, LebesgueMeasure
 
 
@@ -16,6 +16,7 @@ def get_embedding(
     available_embeddings_dict = {
         "expquad-lebesgue": [ExpQuadKernel, LebesgueMeasure],
         "expquad-gaussian": [ExpQuadKernel, GaussianMeasure],
+        "matern-lebesgue": [MaternKernel, LebesgueMeasure],
         "matern12-lebesgue": [Matern12Kernel, LebesgueMeasure],
         "matern12-gaussian": [Matern12Kernel, GaussianMeasure],
         "matern32-lebesgue": [Matern32Kernel, LebesgueMeasure],

--- a/kernel_embedding_dictionary/_get_embedding.py
+++ b/kernel_embedding_dictionary/_get_embedding.py
@@ -5,7 +5,7 @@
 from typing import Optional
 
 from .embeddings import KernelEmbedding
-from .kernels import ExpQuadKernel, MaternKernel, Matern12Kernel, Matern32Kernel, Matern52Kernel, Matern72Kernel
+from .kernels import ExpQuadKernel, MaternNu2Kernel, Matern12Kernel, Matern32Kernel, Matern52Kernel, Matern72Kernel
 from .measures import GaussianMeasure, LebesgueMeasure
 
 
@@ -16,7 +16,7 @@ def get_embedding(
     available_embeddings_dict = {
         "expquad-lebesgue": [ExpQuadKernel, LebesgueMeasure],
         "expquad-gaussian": [ExpQuadKernel, GaussianMeasure],
-        "matern-lebesgue": [MaternKernel, LebesgueMeasure],
+        "matern-lebesgue": [MaternNu2Kernel, LebesgueMeasure],
         "matern12-lebesgue": [Matern12Kernel, LebesgueMeasure],
         "matern12-gaussian": [Matern12Kernel, GaussianMeasure],
         "matern32-lebesgue": [Matern32Kernel, LebesgueMeasure],

--- a/kernel_embedding_dictionary/_get_embedding.py
+++ b/kernel_embedding_dictionary/_get_embedding.py
@@ -5,7 +5,7 @@
 from typing import Optional
 
 from .embeddings import KernelEmbedding
-from .kernels import ExpQuadKernel, MaternNu2Kernel, Matern12Kernel, Matern32Kernel, Matern52Kernel, Matern72Kernel
+from .kernels import ExpQuadKernel, Matern12Kernel, Matern32Kernel, Matern52Kernel, Matern72Kernel, MaternNu2Kernel
 from .measures import GaussianMeasure, LebesgueMeasure
 
 

--- a/kernel_embedding_dictionary/embeddings/embedding.py
+++ b/kernel_embedding_dictionary/embeddings/embedding.py
@@ -11,6 +11,7 @@ from ..measures import ProductMeasure
 from .mean_funcs_1d import (
     expquad_gaussian_mean_func_1d,
     expquad_lebesgue_mean_func_1d,
+    matern_lebesgue_mean_func_1d,
     matern12_gaussian_mean_func_1d,
     matern12_lebesgue_mean_func_1d,
     matern32_gaussian_mean_func_1d,
@@ -59,6 +60,7 @@ class KernelEmbedding:
         mean_func_1d_dict = {
             "expquad-lebesgue": expquad_lebesgue_mean_func_1d,
             "expquad-gaussian": expquad_gaussian_mean_func_1d,
+            "matern-lebesgue": matern_lebesgue_mean_func_1d,
             "matern12-lebesgue": matern12_lebesgue_mean_func_1d,
             "matern12-gaussian": matern12_gaussian_mean_func_1d,
             "matern32-lebesgue": matern32_lebesgue_mean_func_1d,

--- a/kernel_embedding_dictionary/embeddings/embedding.py
+++ b/kernel_embedding_dictionary/embeddings/embedding.py
@@ -11,13 +11,13 @@ from ..measures import ProductMeasure
 from .mean_funcs_1d import (
     expquad_gaussian_mean_func_1d,
     expquad_lebesgue_mean_func_1d,
-    matern_lebesgue_mean_func_1d,
     matern12_gaussian_mean_func_1d,
     matern12_lebesgue_mean_func_1d,
     matern32_gaussian_mean_func_1d,
     matern32_lebesgue_mean_func_1d,
     matern52_lebesgue_mean_func_1d,
     matern72_lebesgue_mean_func_1d,
+    matern_lebesgue_mean_func_1d,
 )
 
 

--- a/kernel_embedding_dictionary/embeddings/mean_funcs_1d.py
+++ b/kernel_embedding_dictionary/embeddings/mean_funcs_1d.py
@@ -3,9 +3,8 @@
 
 
 import numpy as np
-from scipy.special import erf
+from scipy.special import erf, factorial
 from scipy.stats import norm
-from scipy.special import factorial
 
 from kernel_embedding_dictionary.utils import scaled_diff
 

--- a/kernel_embedding_dictionary/embeddings/mean_funcs_1d.py
+++ b/kernel_embedding_dictionary/embeddings/mean_funcs_1d.py
@@ -22,6 +22,7 @@ def expquad_gaussian_mean_func_1d(x: np.ndarray, ell: float, mean: float, varian
     scaled_norm_sq = np.power(scaled_diff(x, mean, np.sqrt(ell**2 + variance), np.sqrt(2)), 2)
     return factor * np.exp(-scaled_norm_sq).reshape(-1)
 
+
 def matern_lebesgue_mean_func_1d(
     x: np.ndarray, ell: float, nu: float, lb: float, ub: float, density: float
 ) -> np.ndarray:
@@ -37,8 +38,9 @@ def matern_lebesgue_mean_func_1d(
     Q_lb = np.exp(-x_lb.reshape(-1)) * np.sum(cs * np.power(x_lb, ms), 1)
     x_ub = (ub - x) / alpha
     Q_ub = np.exp(-x_ub.reshape(-1)) * np.sum(cs * np.power(x_ub, ms), 1)
-    kernel_mean = alpha * factorial(n) / factorial(2*n) * (2 * cs[0] - Q_lb - Q_ub)
+    kernel_mean = alpha * factorial(n) / factorial(2 * n) * (2 * cs[0] - Q_lb - Q_ub)
     return density * kernel_mean
+
 
 def matern12_lebesgue_mean_func_1d(
     x: np.ndarray, ell: float, nu: float, lb: float, ub: float, density: float
@@ -47,6 +49,7 @@ def matern12_lebesgue_mean_func_1d(
     exp_x_ub = np.exp(scaled_diff(x, ub, ell, 1))
     kernel_mean = ell * (2.0 - exp_lb_x - exp_x_ub)
     return density * kernel_mean.reshape(-1)
+
 
 def matern12_gaussian_mean_func_1d(x: np.ndarray, ell: float, nu: float, mean: float, variance: float) -> np.ndarray:
 

--- a/kernel_embedding_dictionary/kernels/__init__.py
+++ b/kernel_embedding_dictionary/kernels/__init__.py
@@ -4,7 +4,7 @@
 
 from .expquad_kernel import ExpQuadKernel, ExpQuadKernelUni
 from .kernel import ProductKernel, UnivariateKernel
-from .matern_kernel import MaternKernel, MaternKernelUni
+from .matern_kernel import MaternNu2Kernel, MaternNu2KernelUni
 from .matern12_kernel import Matern12Kernel, Matern12KernelUni
 from .matern13_kernel import Matern32Kernel, Matern32KernelUni
 from .matern52_kernel import Matern52Kernel, Matern52KernelUni
@@ -14,13 +14,13 @@ __all__ = [
     "ProductKernel",
     "UnivariateKernel",
     "ExpQuadKernel",
-    "MaternKernel",
+    "MaternNu2Kernel",
     "Matern12Kernel",
     "Matern32Kernel",
     "Matern52Kernel",
     "Matern72Kernel",
     "ExpQuadKernelUni",
-    "MaternKernelUni",
+    "MaternNu2KernelUni",
     "Matern12KernelUni",
     "Matern32KernelUni",
     "Matern52KernelUni",

--- a/kernel_embedding_dictionary/kernels/__init__.py
+++ b/kernel_embedding_dictionary/kernels/__init__.py
@@ -4,11 +4,11 @@
 
 from .expquad_kernel import ExpQuadKernel, ExpQuadKernelUni
 from .kernel import ProductKernel, UnivariateKernel
-from .matern_kernel import MaternNu2Kernel, MaternNu2KernelUni
 from .matern12_kernel import Matern12Kernel, Matern12KernelUni
 from .matern13_kernel import Matern32Kernel, Matern32KernelUni
 from .matern52_kernel import Matern52Kernel, Matern52KernelUni
 from .matern72_kernel import Matern72Kernel, Matern72KernelUni
+from .matern_kernel import MaternNu2Kernel, MaternNu2KernelUni
 
 __all__ = [
     "ProductKernel",

--- a/kernel_embedding_dictionary/kernels/__init__.py
+++ b/kernel_embedding_dictionary/kernels/__init__.py
@@ -4,6 +4,7 @@
 
 from .expquad_kernel import ExpQuadKernel, ExpQuadKernelUni
 from .kernel import ProductKernel, UnivariateKernel
+from .matern_kernel import MaternKernel, MaternKernelUni
 from .matern12_kernel import Matern12Kernel, Matern12KernelUni
 from .matern13_kernel import Matern32Kernel, Matern32KernelUni
 from .matern52_kernel import Matern52Kernel, Matern52KernelUni
@@ -13,11 +14,13 @@ __all__ = [
     "ProductKernel",
     "UnivariateKernel",
     "ExpQuadKernel",
+    "MaternKernel",
     "Matern12Kernel",
     "Matern32Kernel",
     "Matern52Kernel",
     "Matern72Kernel",
     "ExpQuadKernelUni",
+    "MaternKernelUni",
     "Matern12KernelUni",
     "Matern32KernelUni",
     "Matern52KernelUni",

--- a/kernel_embedding_dictionary/kernels/matern_kernel.py
+++ b/kernel_embedding_dictionary/kernels/matern_kernel.py
@@ -17,7 +17,7 @@ class MaternNu2KernelUni(UnivariateKernel):
         if ell <= 0:
             raise ValueError(f"ell ({ell}) must be positive")
 
-        if not ( int(nu + 0.5) == nu + 0.5 and nu > 0 ):
+        if not (int(nu + 0.5) == nu + 0.5 and nu > 0):
             raise ValueError(f"only kernels and embeddings for positive half-integer nu ({nu}) are implemented")
 
         self.ell = ell
@@ -31,11 +31,13 @@ class MaternNu2KernelUni(UnivariateKernel):
         n2 = x2.shape[0]
         K = np.zeros([n1, n2])
         n = int(self.nu)
-        ks = np.arange(n+1)
-        coefs =  factorial(n) / factorial(2 * n) * np.power(2, ks) * factorial(n + ks) / factorial(ks) / factorial(n - ks)
+        ks = np.arange(n + 1)
+        coefs = (
+            factorial(n) / factorial(2 * n) * np.power(2, ks) * factorial(n + ks) / factorial(ks) / factorial(n - ks)
+        )
         for i in range(n1):
             for j in range(n2):
-                abs_diff = np.sqrt( 2 *self.nu) * abs(scaled_diff(x1[i], x2[j], self.ell, 1))
+                abs_diff = np.sqrt(2 * self.nu) * abs(scaled_diff(x1[i], x2[j], self.ell, 1))
                 abs_diff_powers = np.power(abs_diff, n - ks)
                 K[i, j] = np.exp(-abs_diff) * np.sum(coefs * abs_diff_powers)
         return K
@@ -74,10 +76,15 @@ class MaternNu2Kernel(ProductKernel):
 
     @property
     def nu(self) -> float:
-        return self._nu 
+        return self._nu
 
     def __str__(self) -> str:
-        return f"Matern kernel \n" f"order: {self.nu} \n" f"dimensionality: {self.ndim} \n" f"lengthscales: {list(self.ell)}"
+        return (
+            f"Matern kernel \n"
+            f"order: {self.nu} \n"
+            f"dimensionality: {self.ndim} \n"
+            f"lengthscales: {list(self.ell)}"
+        )
 
     def __repr__(self) -> str:
         return "Matern kernel"

--- a/kernel_embedding_dictionary/kernels/matern_kernel.py
+++ b/kernel_embedding_dictionary/kernels/matern_kernel.py
@@ -66,11 +66,15 @@ class MaternNu2Kernel(ProductKernel):
         kernels = [MaternNu2KernelUni(nu=nu, ell=elli) for elli in ell]
         super().__init__(name="matern", kernel_list=kernels)  # sets name, ndim and kernel list
 
-        self.nu = nu
+        self._nu = nu
 
     @property
     def ell(self) -> List[float]:
         return [k.ell for k in self._kernels]
+
+    @property
+    def nu(self) -> float:
+        return self._nu 
 
     def __str__(self) -> str:
         return f"Matern kernel \n" f"order: {self.nu} \n" f"dimensionality: {self.ndim} \n" f"lengthscales: {list(self.ell)}"

--- a/kernel_embedding_dictionary/kernels/matern_kernel.py
+++ b/kernel_embedding_dictionary/kernels/matern_kernel.py
@@ -1,0 +1,79 @@
+# Copyright 2025 The KED Authors. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+
+
+from typing import List, Optional
+
+import numpy as np
+from scipy.special import factorial
+
+from ..utils import scaled_diff
+from .kernel import ProductKernel, UnivariateKernel
+
+
+class MaternKernelUni(UnivariateKernel):
+    def __init__(self, nu: float, ell: float):
+
+        if ell <= 0:
+            raise ValueError(f"ell ({ell}) must be positive")
+
+        if not ( int(nu + 0.5) == nu + 0.5 and nu > 0 ):
+            raise ValueError(f"only kernels and embeddings for positive half-integer nu ({nu}) are implemented")
+
+        self.ell = ell
+        self.nu = nu
+
+    def get_param_dict(self) -> dict:
+        return {"ell": self.ell, "nu": self.nu}
+
+    def _evaluate(self, x1: np.ndarray, x2: np.ndarray) -> np.ndarray:
+        n1 = x1.shape[0]
+        n2 = x2.shape[0]
+        K = np.zeros([n1, n2])
+        n = int(self.nu)
+        ks = np.arange(n+1)
+        coefs =  factorial(n) / factorial(2 * n) * np.power(2, ks) * factorial(n + ks) / factorial(ks) / factorial(n - ks)
+        for i in range(n1):
+            for j in range(n2):
+                abs_diff = np.sqrt( 2 *self.nu) * abs(scaled_diff(x1[i], x2[j], self.ell, 1))
+                abs_diff_powers = np.power(abs_diff, n - ks)
+                K[i, j] = np.exp(-abs_diff) * np.sum(coefs * abs_diff_powers)
+        return K
+
+
+class MaternKernel(ProductKernel):
+    def __init__(self, config: Optional[dict] = None):
+        """
+
+        :param config: needs to contain nu, ells and/or ndim
+        """
+
+        if config is None:
+            config = {}
+
+        # dimensionality and bounds
+        nu = config.get("nu", 2.5)
+        ell = config.get("lengthscales", [1.0])
+        ndim = config.get("ndim", None)
+
+        if ndim is not None:
+            if (ndim > 1) and (len(ell) == 1):
+                ell = ndim * [ell[0]]
+            else:
+                if ndim != len(ell):
+                    raise ValueError(f"ndim ({ndim}) and dimensionality of lengthscales ({len(ell)}) does not match.")
+
+        kernels = [MaternKernelUni(nu=nu, ell=elli) for elli in ell]
+        super().__init__(name="matern", kernel_list=kernels)  # sets name, ndim and kernel list
+
+        self.nu = nu
+
+    @property
+    def ell(self) -> List[float]:
+        return [k.ell for k in self._kernels]
+
+    def __str__(self) -> str:
+        return f"Matern kernel \n" f"order: {self.nu} \n" f"dimensionality: {self.ndim} \n" f"lengthscales: {list(self.ell)}"
+
+    def __repr__(self) -> str:
+        return "Matern kernel"

--- a/kernel_embedding_dictionary/kernels/matern_kernel.py
+++ b/kernel_embedding_dictionary/kernels/matern_kernel.py
@@ -11,7 +11,7 @@ from ..utils import scaled_diff
 from .kernel import ProductKernel, UnivariateKernel
 
 
-class MaternKernelUni(UnivariateKernel):
+class MaternNu2KernelUni(UnivariateKernel):
     def __init__(self, nu: float, ell: float):
 
         if ell <= 0:
@@ -41,7 +41,7 @@ class MaternKernelUni(UnivariateKernel):
         return K
 
 
-class MaternKernel(ProductKernel):
+class MaternNu2Kernel(ProductKernel):
     def __init__(self, config: Optional[dict] = None):
         """
 
@@ -63,7 +63,7 @@ class MaternKernel(ProductKernel):
                 if ndim != len(ell):
                     raise ValueError(f"ndim ({ndim}) and dimensionality of lengthscales ({len(ell)}) does not match.")
 
-        kernels = [MaternKernelUni(nu=nu, ell=elli) for elli in ell]
+        kernels = [MaternNu2KernelUni(nu=nu, ell=elli) for elli in ell]
         super().__init__(name="matern", kernel_list=kernels)  # sets name, ndim and kernel list
 
         self.nu = nu

--- a/tests/kernel_embedding_dictionary/embeddings/test_mean_values_matern.py
+++ b/tests/kernel_embedding_dictionary/embeddings/test_mean_values_matern.py
@@ -1,0 +1,131 @@
+# Copyright 2025 The KED Authors. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+
+
+import numpy as np
+import pytest
+
+from kernel_embedding_dictionary._get_embedding import get_embedding
+
+
+def get_config_matern_lebesgue_1d_standard():
+    ck = {"ndim": 1}
+    cm = {"ndim": 1}
+    x = np.array([[0.1], [0.5], [0.9]])  # 3x1 must lie in domain
+    return "matern", "lebesgue", ck, cm, x
+
+
+def get_config_matern_lebesgue_1d_values():
+    ck = {"ndim": 1, "lengthscales": [0.3]}
+    cm = {"ndim": 1, "bounds": [(-0.5, 2.5)], "normalize": True}  # test only works for normalized measures
+    x = np.array([[0.1], [0.5], [0.85]])  # 3x1 must lie in domain
+    return "matern", "lebesgue", ck, cm, x
+
+
+def get_config_matern_lebesgue_2d_standard():
+    ck = {"ndim": 2}
+    cm = {"ndim": 2}
+    x = np.array([[0.1, 0.2], [0.5, 0.5], [0.9, 0.2]])  # 3x2 must lie in domain
+    return "matern", "lebesgue", ck, cm, x
+
+
+def get_config_matern_lebesgue_2d_values():
+    ck = {"ndim": 2, "lengthscales": [0.03, 1.6]}
+    cm = {"ndim": 2, "bounds": [(-0.5, 2.5), (-1.5, 0.1)], "normalize": True}  # test only works for normalized measures
+    x = np.array([[-0.3, -1], [0.0, -0.2], [1.5, 0.0]])  # 3x2 must lie in domain
+    return "matern", "lebesgue", ck, cm, x
+
+
+@pytest.fixture()
+def config_matern_lebesgue_1d_standard():
+    kn, mn, ck, cm, x = get_config_matern_lebesgue_1d_standard()
+    return kn, mn, ck, cm, x
+
+
+@pytest.fixture()
+def config_matern_lebesgue_1d_values():
+    kn, mn, ck, cm, x = get_config_matern_lebesgue_1d_values()
+    return kn, mn, ck, cm, x
+
+
+@pytest.fixture()
+def config_matern_lebesgue_2d_standard():
+    kn, mn, ck, cm, x = get_config_matern_lebesgue_2d_standard()
+    return kn, mn, ck, cm, x
+
+
+@pytest.fixture()
+def config_matern_lebesgue_2d_values():
+    kn, mn, ck, cm, x = get_config_matern_lebesgue_2d_values()
+    return kn, mn, ck, cm, x
+
+
+fixture_list = [
+    "config_matern_lebesgue_1d_standard",
+    "config_matern_lebesgue_1d_values",
+    "config_matern_lebesgue_2d_standard",
+    "config_matern_lebesgue_2d_values",
+]
+
+
+@pytest.mark.parametrize("fixture_name", fixture_list)
+def test_embedding_mean_values_closed_form(fixture_name, request):
+    kn, mn, ck, cm, x_eval = request.getfixturevalue(fixture_name)
+
+    # Matern 1/2
+    ck2 = ck.copy()
+    ck2.update({"nu": 0.5})
+    ke = get_embedding(kernel_name=kn, measure_name=mn, kernel_config=ck2, measure_config=cm)
+    ke_explicit = get_embedding(kernel_name=kn + "12", measure_name=mn, kernel_config=ck, measure_config=cm)
+
+    res = ke.mean(x_eval)
+    res_explicit = ke_explicit.mean(x_eval)
+    for i in range(x_eval.shape[0]):
+        print(i)
+        print(res)
+        print(res_explicit)
+        assert res[i] == pytest.approx(res_explicit[i])
+
+
+    # Matern 3/2
+    ck2 = ck.copy()
+    ck2.update({"nu": 1.5})
+    ke = get_embedding(kernel_name=kn, measure_name=mn, kernel_config=ck2, measure_config=cm)
+    ke_explicit = get_embedding(kernel_name=kn + "32", measure_name=mn, kernel_config=ck, measure_config=cm)
+
+    res = ke.mean(x_eval)
+    res_explicit = ke_explicit.mean(x_eval)
+    for i in range(x_eval.shape[0]):
+        print(i)
+        print(res)
+        print(res_explicit)
+        assert res[i] == pytest.approx(res_explicit[i])
+
+    # Matern 5/2
+    ck2 = ck.copy()
+    ck2.update({"nu": 2.5})
+    ke = get_embedding(kernel_name=kn, measure_name=mn, kernel_config=ck2, measure_config=cm)
+    ke_explicit = get_embedding(kernel_name=kn + "52", measure_name=mn, kernel_config=ck, measure_config=cm)
+
+    res = ke.mean(x_eval)
+    res_explicit = ke_explicit.mean(x_eval)
+    for i in range(x_eval.shape[0]):
+        print(i)
+        print(res)
+        print(res_explicit)
+        assert res[i] == pytest.approx(res_explicit[i])
+
+    # Matern 7/2
+    ck2 = ck.copy()
+    ck2.update({"nu": 3.5})
+    ke = get_embedding(kernel_name=kn, measure_name=mn, kernel_config=ck2, measure_config=cm)
+    ke_explicit = get_embedding(kernel_name=kn + "72", measure_name=mn, kernel_config=ck, measure_config=cm)
+
+    res = ke.mean(x_eval)
+    res_explicit = ke_explicit.mean(x_eval)
+    for i in range(x_eval.shape[0]):
+        print(i)
+        print(res)
+        print(res_explicit)
+        assert res[i] == pytest.approx(res_explicit[i])
+

--- a/tests/kernel_embedding_dictionary/embeddings/test_mean_values_matern.py
+++ b/tests/kernel_embedding_dictionary/embeddings/test_mean_values_matern.py
@@ -68,63 +68,20 @@ fixture_list = [
 ]
 
 
+@pytest.mark.parametrize("nu_set", [("12", 0.5), ("32", 1.5), ("52", 2.5), ("72", 3.5)])
 @pytest.mark.parametrize("fixture_name", fixture_list)
-def test_embedding_mean_values_closed_form(fixture_name, request):
+def test_embedding_mean_values_closed_form(nu_set, fixture_name, request):
     kn, mn, ck, cm, x_eval = request.getfixturevalue(fixture_name)
+    nu_suffix, nu = nu_set
 
-    # Matern 1/2
-    ck2 = ck.copy()
-    ck2.update({"nu": 0.5})
-    ke = get_embedding(kernel_name=kn, measure_name=mn, kernel_config=ck2, measure_config=cm)
-    ke_explicit = get_embedding(kernel_name=kn + "12", measure_name=mn, kernel_config=ck, measure_config=cm)
-
-    res = ke.mean(x_eval)
-    res_explicit = ke_explicit.mean(x_eval)
-    for i in range(x_eval.shape[0]):
-        print(i)
-        print(res)
-        print(res_explicit)
-        assert res[i] == pytest.approx(res_explicit[i])
-
-
-    # Matern 3/2
-    ck2 = ck.copy()
-    ck2.update({"nu": 1.5})
-    ke = get_embedding(kernel_name=kn, measure_name=mn, kernel_config=ck2, measure_config=cm)
-    ke_explicit = get_embedding(kernel_name=kn + "32", measure_name=mn, kernel_config=ck, measure_config=cm)
+    ck.update({"nu": nu})
+    ke = get_embedding(kernel_name=kn, measure_name=mn, kernel_config=ck, measure_config=cm)
+    ke_explicit = get_embedding(kernel_name=kn + nu_suffix, measure_name=mn, kernel_config=ck, measure_config=cm)
 
     res = ke.mean(x_eval)
     res_explicit = ke_explicit.mean(x_eval)
     for i in range(x_eval.shape[0]):
-        print(i)
-        print(res)
-        print(res_explicit)
-        assert res[i] == pytest.approx(res_explicit[i])
-
-    # Matern 5/2
-    ck2 = ck.copy()
-    ck2.update({"nu": 2.5})
-    ke = get_embedding(kernel_name=kn, measure_name=mn, kernel_config=ck2, measure_config=cm)
-    ke_explicit = get_embedding(kernel_name=kn + "52", measure_name=mn, kernel_config=ck, measure_config=cm)
-
-    res = ke.mean(x_eval)
-    res_explicit = ke_explicit.mean(x_eval)
-    for i in range(x_eval.shape[0]):
-        print(i)
-        print(res)
-        print(res_explicit)
-        assert res[i] == pytest.approx(res_explicit[i])
-
-    # Matern 7/2
-    ck2 = ck.copy()
-    ck2.update({"nu": 3.5})
-    ke = get_embedding(kernel_name=kn, measure_name=mn, kernel_config=ck2, measure_config=cm)
-    ke_explicit = get_embedding(kernel_name=kn + "72", measure_name=mn, kernel_config=ck, measure_config=cm)
-
-    res = ke.mean(x_eval)
-    res_explicit = ke_explicit.mean(x_eval)
-    for i in range(x_eval.shape[0]):
-        print(i)
+        print(i, nu)
         print(res)
         print(res_explicit)
         assert res[i] == pytest.approx(res_explicit[i])

--- a/tests/kernel_embedding_dictionary/embeddings/test_mean_values_matern.py
+++ b/tests/kernel_embedding_dictionary/embeddings/test_mean_values_matern.py
@@ -85,4 +85,3 @@ def test_embedding_mean_values_closed_form(nu_set, fixture_name, request):
         print(res)
         print(res_explicit)
         assert res[i] == pytest.approx(res_explicit[i])
-

--- a/tests/kernel_embedding_dictionary/kernels/test_kernels.py
+++ b/tests/kernel_embedding_dictionary/kernels/test_kernels.py
@@ -7,6 +7,7 @@ import pytest
 
 from kernel_embedding_dictionary.kernels import (
     ExpQuadKernel,
+    MaternNu2Kernel,
     Matern12Kernel,
     Matern32Kernel,
     Matern52Kernel,
@@ -19,6 +20,10 @@ def expquad():
     c = {"ndim": 2}
     return ExpQuadKernel(c)
 
+@pytest.fixture()
+def matern():
+    c = {"ndim": 2}
+    return MaternNu2Kernel(c)
 
 @pytest.fixture()
 def matern12():
@@ -45,7 +50,7 @@ def matern72():
 
 
 # for a new kernel: add a fixture and its name to the list
-kernel_list = ["expquad", "matern12", "matern32", "matern52", "matern72"]
+kernel_list = ["expquad", "matern", "matern12", "matern32", "matern52", "matern72"]
 
 
 @pytest.mark.parametrize("kernel_name", kernel_list)

--- a/tests/kernel_embedding_dictionary/kernels/test_kernels.py
+++ b/tests/kernel_embedding_dictionary/kernels/test_kernels.py
@@ -7,11 +7,11 @@ import pytest
 
 from kernel_embedding_dictionary.kernels import (
     ExpQuadKernel,
-    MaternNu2Kernel,
     Matern12Kernel,
     Matern32Kernel,
     Matern52Kernel,
     Matern72Kernel,
+    MaternNu2Kernel,
 )
 
 

--- a/tests/kernel_embedding_dictionary/kernels/test_kernels.py
+++ b/tests/kernel_embedding_dictionary/kernels/test_kernels.py
@@ -20,10 +20,12 @@ def expquad():
     c = {"ndim": 2}
     return ExpQuadKernel(c)
 
+
 @pytest.fixture()
 def matern():
     c = {"ndim": 2}
     return MaternNu2Kernel(c)
+
 
 @pytest.fixture()
 def matern12():

--- a/tests/kernel_embedding_dictionary/kernels/test_kernels_uni.py
+++ b/tests/kernel_embedding_dictionary/kernels/test_kernels_uni.py
@@ -7,6 +7,7 @@ import pytest
 
 from kernel_embedding_dictionary.kernels import (
     ExpQuadKernelUni,
+    MaternNu2KernelUni,
     Matern12KernelUni,
     Matern32KernelUni,
     Matern52KernelUni,
@@ -17,6 +18,11 @@ from kernel_embedding_dictionary.kernels import (
 @pytest.fixture()
 def expquad_uni():
     return ExpQuadKernelUni(ell=1.0)
+
+
+@pytest.fixture()
+def matern_uni():
+    return MaternNu2KernelUni(nu=8.5, ell=1.0)
 
 
 @pytest.fixture()
@@ -40,7 +46,7 @@ def matern72_uni():
 
 
 # for a new univariate kernel: add a fixture and its name to the list
-kernel_uni_list = ["expquad_uni", "matern12_uni", "matern32_uni", "matern52_uni", "matern72_uni"]
+kernel_uni_list = ["expquad_uni", "matern_uni", "matern12_uni", "matern32_uni", "matern52_uni", "matern72_uni"]
 
 
 @pytest.mark.parametrize("kernel_uni_name", kernel_uni_list)

--- a/tests/kernel_embedding_dictionary/kernels/test_kernels_uni.py
+++ b/tests/kernel_embedding_dictionary/kernels/test_kernels_uni.py
@@ -7,11 +7,11 @@ import pytest
 
 from kernel_embedding_dictionary.kernels import (
     ExpQuadKernelUni,
-    MaternNu2KernelUni,
     Matern12KernelUni,
     Matern32KernelUni,
     Matern52KernelUni,
     Matern72KernelUni,
+    MaternNu2KernelUni,
 )
 
 

--- a/tests/kernel_embedding_dictionary/kernels/test_matern_kernel.py
+++ b/tests/kernel_embedding_dictionary/kernels/test_matern_kernel.py
@@ -2,15 +2,21 @@
 # SPDX-License-Identifier: MIT
 
 
-import pytest
 import numpy as np
+import pytest
 
-from kernel_embedding_dictionary.kernels import MaternNu2Kernel, MaternNu2KernelUni
-
-from kernel_embedding_dictionary.kernels import Matern12Kernel, Matern12KernelUni
-from kernel_embedding_dictionary.kernels import Matern32Kernel, Matern32KernelUni
-from kernel_embedding_dictionary.kernels import Matern52Kernel, Matern52KernelUni
-from kernel_embedding_dictionary.kernels import Matern72Kernel, Matern72KernelUni
+from kernel_embedding_dictionary.kernels import (
+    Matern12Kernel,
+    Matern12KernelUni,
+    Matern32Kernel,
+    Matern32KernelUni,
+    Matern52Kernel,
+    Matern52KernelUni,
+    Matern72Kernel,
+    Matern72KernelUni,
+    MaternNu2Kernel,
+    MaternNu2KernelUni,
+)
 
 
 # tests for MaternKernelUni start here

--- a/tests/kernel_embedding_dictionary/kernels/test_matern_kernel.py
+++ b/tests/kernel_embedding_dictionary/kernels/test_matern_kernel.py
@@ -5,7 +5,7 @@
 import pytest
 import numpy as np
 
-from kernel_embedding_dictionary.kernels import MaternKernel, MaternKernelUni
+from kernel_embedding_dictionary.kernels import MaternNu2Kernel, MaternNu2KernelUni
 
 from kernel_embedding_dictionary.kernels import Matern12Kernel, Matern12KernelUni
 from kernel_embedding_dictionary.kernels import Matern32Kernel, Matern32KernelUni
@@ -17,7 +17,7 @@ def test_matern_kernel_uni_values():
 
     ell = 1.5
     nu = 7.5
-    k = MaternKernelUni(nu=nu, ell=ell)
+    k = MaternNu2KernelUni(nu=nu, ell=ell)
     assert k.ell == ell
     assert k.nu == nu
 
@@ -26,7 +26,7 @@ def test_matern_kernel_uni_param_dict():
 
     ell = 1.2
     nu = 0.5
-    k = MaternKernelUni(nu=nu, ell=ell)
+    k = MaternNu2KernelUni(nu=nu, ell=ell)
     p = k.get_param_dict()
 
     # this check is important due to how the kernel embedding params are assembled
@@ -40,22 +40,22 @@ def test_matern_kernel_uni_raises():
     # negative lengthscale
     wrong_ell = -1.0
     with pytest.raises(ValueError):
-        MaternKernelUni(nu=0.5, ell=wrong_ell)
+        MaternNu2KernelUni(nu=0.5, ell=wrong_ell)
 
     # zero lengthscale
     wrong_ell = 0.0
     with pytest.raises(ValueError):
-        MaternKernelUni(nu=0.5, ell=wrong_ell)
+        MaternNu2KernelUni(nu=0.5, ell=wrong_ell)
 
     # negative nu
     wrong_nu = -0.5
     with pytest.raises(ValueError):
-        MaternKernelUni(nu=wrong_nu, ell=1.0)
+        MaternNu2KernelUni(nu=wrong_nu, ell=1.0)
 
     # non-half-integer nu
     wrong_nu = 2.55
     with pytest.raises(ValueError):
-        MaternKernelUni(nu=wrong_nu, ell=1.0)
+        MaternNu2KernelUni(nu=wrong_nu, ell=1.0)
 
 
 def test_matern_kernel_uni_evaluations():
@@ -65,22 +65,22 @@ def test_matern_kernel_uni_evaluations():
 
     # Matern 1/2
     k1 = Matern12KernelUni(ell=ell)
-    k2 = MaternKernelUni(nu=0.5, ell=ell)
+    k2 = MaternNu2KernelUni(nu=0.5, ell=ell)
     assert (k1.evaluate(x, x) == k2.evaluate(x, x)).all
 
     # Matern 3/2
     k1 = Matern32KernelUni(ell=ell)
-    k2 = MaternKernelUni(nu=1.5, ell=ell)
+    k2 = MaternNu2KernelUni(nu=1.5, ell=ell)
     assert (k1.evaluate(x, x) == k2.evaluate(x, x)).all
 
     # Matern 5/2
     k1 = Matern52KernelUni(ell=ell)
-    k2 = MaternKernelUni(nu=2.5, ell=ell)
+    k2 = MaternNu2KernelUni(nu=2.5, ell=ell)
     assert (k1.evaluate(x, x) == k2.evaluate(x, x)).all
 
     # Matern 7/2
     k1 = Matern72KernelUni(ell=ell)
-    k2 = MaternKernelUni(nu=3.5, ell=ell)
+    k2 = MaternNu2KernelUni(nu=3.5, ell=ell)
     assert (k1.evaluate(x, x) == k2.evaluate(x, x)).all 
 
 # tests for MaternKernel start here
@@ -88,7 +88,7 @@ def test_matern_kernel_defaults():
 
     # only nu given
     c = {"nu": 1.5}
-    k = MaternKernel(c)
+    k = MaternNu2Kernel(c)
     assert k.ndim == 1
     assert k.ell == [1.0]
     assert len(k._kernels) == 1
@@ -96,7 +96,7 @@ def test_matern_kernel_defaults():
 
     # only nu and ndim given
     c = {"nu": 2.5, "ndim": 2}
-    k = MaternKernel(c)
+    k = MaternNu2Kernel(c)
     assert k.ndim == 2
     assert k.ell == [1.0, 1.0]
     assert len(k._kernels) == 2
@@ -104,7 +104,7 @@ def test_matern_kernel_defaults():
 
     # only ell given
     c = {"lengthscales": [1.0, 2.0]}
-    k = MaternKernel(config=c)
+    k = MaternNu2Kernel(config=c)
     assert k.ndim == 2
     assert k.ell == [1.0, 2.0]
     assert len(k._kernels) == 2
@@ -115,7 +115,7 @@ def test_matern_kernel_values():
 
     # all values given, no defaults
     c = {"nu": 3.5, "ndim": 2, "lengthscales": [1.0, 2.0]}
-    k = MaternKernel(config=c)
+    k = MaternNu2Kernel(config=c)
     assert k.ndim == 2
     assert k.ell == [1.0, 2.0]
     assert len(k._kernels) == 2
@@ -127,7 +127,7 @@ def test_matern_kernel_raises():
     # ndim and lengthscales do not match
     wrong_c = {"nu": 0.5, "ndim": 1, "lengthscales": [1.0, 1.0]}
     with pytest.raises(ValueError):
-        MaternKernel(wrong_c)
+        MaternNu2Kernel(wrong_c)
 
 def test_matern_kernel_evaluations():
 
@@ -137,26 +137,26 @@ def test_matern_kernel_evaluations():
     c1 = {"ndim": 2, "lengthscales": [1.0, 0.5]}
     c2 = {"nu": 0.5, "ndim": 2, "lengthscales": [1.0, 0.5]}
     k1 = Matern12Kernel(c1)
-    k2 = MaternKernel(c2)
+    k2 = MaternNu2Kernel(c2)
     assert (k1.evaluate(x, x) == k2.evaluate(x, x)).all
 
     # # Matern 3/2
     c1 = {"ndim": 2, "lengthscales": [1.0, 0.5]}
     c2 = {"nu": 1.5, "ndim": 2, "lengthscales": [1.0, 0.5]}
     k1 = Matern32Kernel(c1)
-    k2 = MaternKernel(c2)
+    k2 = MaternNu2Kernel(c2)
     assert (k1.evaluate(x, x) == k2.evaluate(x, x)).all
 
     # # Matern 5/2
     c1 = {"ndim": 2, "lengthscales": [1.0, 0.5]}
     c2 = {"nu": 2.5, "ndim": 2, "lengthscales": [1.0, 0.5]}
     k1 = Matern52Kernel(c1)
-    k2 = MaternKernel(c2)
+    k2 = MaternNu2Kernel(c2)
     assert (k1.evaluate(x, x) == k2.evaluate(x, x)).all
 
     # # Matern 7/2
     c1 = {"ndim": 2, "lengthscales": [1.0, 0.5]}
     c2 = {"nu": 3.5, "ndim": 2, "lengthscales": [1.0, 0.5]}
     k1 = Matern72Kernel(c1)
-    k2 = MaternKernel(c2)
+    k2 = MaternNu2Kernel(c2)
     assert (k1.evaluate(x, x) == k2.evaluate(x, x)).all

--- a/tests/kernel_embedding_dictionary/kernels/test_matern_kernel.py
+++ b/tests/kernel_embedding_dictionary/kernels/test_matern_kernel.py
@@ -1,0 +1,162 @@
+# Copyright 2025 The KED Authors. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+
+
+import pytest
+import numpy as np
+
+from kernel_embedding_dictionary.kernels import MaternKernel, MaternKernelUni
+
+from kernel_embedding_dictionary.kernels import Matern12Kernel, Matern12KernelUni
+from kernel_embedding_dictionary.kernels import Matern32Kernel, Matern32KernelUni
+from kernel_embedding_dictionary.kernels import Matern52Kernel, Matern52KernelUni
+from kernel_embedding_dictionary.kernels import Matern72Kernel, Matern72KernelUni
+
+# tests for MaternKernelUni start here
+def test_matern_kernel_uni_values():
+
+    ell = 1.5
+    nu = 7.5
+    k = MaternKernelUni(nu=nu, ell=ell)
+    assert k.ell == ell
+    assert k.nu == nu
+
+
+def test_matern_kernel_uni_param_dict():
+
+    ell = 1.2
+    nu = 0.5
+    k = MaternKernelUni(nu=nu, ell=ell)
+    p = k.get_param_dict()
+
+    # this check is important due to how the kernel embedding params are assembled
+    assert set(p.keys()) == {"ell", "nu"}
+    assert p["ell"] == ell
+    assert p["nu"] == nu
+
+
+def test_matern_kernel_uni_raises():
+
+    # negative lengthscale
+    wrong_ell = -1.0
+    with pytest.raises(ValueError):
+        MaternKernelUni(nu=0.5, ell=wrong_ell)
+
+    # zero lengthscale
+    wrong_ell = 0.0
+    with pytest.raises(ValueError):
+        MaternKernelUni(nu=0.5, ell=wrong_ell)
+
+    # negative nu
+    wrong_nu = -0.5
+    with pytest.raises(ValueError):
+        MaternKernelUni(nu=wrong_nu, ell=1.0)
+
+    # non-half-integer nu
+    wrong_nu = 2.55
+    with pytest.raises(ValueError):
+        MaternKernelUni(nu=wrong_nu, ell=1.0)
+
+
+def test_matern_kernel_uni_evaluations():
+
+    ell = 1.8
+    x = np.array([0, -1.0, 0.123, 3.144365, 2, 1.0])
+
+    # Matern 1/2
+    k1 = Matern12KernelUni(ell=ell)
+    k2 = MaternKernelUni(nu=0.5, ell=ell)
+    assert (k1.evaluate(x, x) == k2.evaluate(x, x)).all
+
+    # Matern 3/2
+    k1 = Matern32KernelUni(ell=ell)
+    k2 = MaternKernelUni(nu=1.5, ell=ell)
+    assert (k1.evaluate(x, x) == k2.evaluate(x, x)).all
+
+    # Matern 5/2
+    k1 = Matern52KernelUni(ell=ell)
+    k2 = MaternKernelUni(nu=2.5, ell=ell)
+    assert (k1.evaluate(x, x) == k2.evaluate(x, x)).all
+
+    # Matern 7/2
+    k1 = Matern72KernelUni(ell=ell)
+    k2 = MaternKernelUni(nu=3.5, ell=ell)
+    assert (k1.evaluate(x, x) == k2.evaluate(x, x)).all 
+
+# tests for MaternKernel start here
+def test_matern_kernel_defaults():
+
+    # only nu given
+    c = {"nu": 1.5}
+    k = MaternKernel(c)
+    assert k.ndim == 1
+    assert k.ell == [1.0]
+    assert len(k._kernels) == 1
+    assert k.nu == 1.5
+
+    # only nu and ndim given
+    c = {"nu": 2.5, "ndim": 2}
+    k = MaternKernel(c)
+    assert k.ndim == 2
+    assert k.ell == [1.0, 1.0]
+    assert len(k._kernels) == 2
+    assert k.nu == 2.5
+
+    # only ell given
+    c = {"lengthscales": [1.0, 2.0]}
+    k = MaternKernel(config=c)
+    assert k.ndim == 2
+    assert k.ell == [1.0, 2.0]
+    assert len(k._kernels) == 2
+    assert k.nu == 2.5
+
+
+def test_matern_kernel_values():
+
+    # all values given, no defaults
+    c = {"nu": 3.5, "ndim": 2, "lengthscales": [1.0, 2.0]}
+    k = MaternKernel(config=c)
+    assert k.ndim == 2
+    assert k.ell == [1.0, 2.0]
+    assert len(k._kernels) == 2
+    assert k.nu == 3.5
+
+
+def test_matern_kernel_raises():
+
+    # ndim and lengthscales do not match
+    wrong_c = {"nu": 0.5, "ndim": 1, "lengthscales": [1.0, 1.0]}
+    with pytest.raises(ValueError):
+        MaternKernel(wrong_c)
+
+def test_matern_kernel_evaluations():
+
+    x = np.array([[0, 0], [-1.5, -1.0], [1.0, 0.123], [2, 3.144365], [2, 3], [1.0, 1]])
+
+    # Matern 1/2
+    c1 = {"ndim": 2, "lengthscales": [1.0, 0.5]}
+    c2 = {"nu": 0.5, "ndim": 2, "lengthscales": [1.0, 0.5]}
+    k1 = Matern12Kernel(c1)
+    k2 = MaternKernel(c2)
+    assert (k1.evaluate(x, x) == k2.evaluate(x, x)).all
+
+    # # Matern 3/2
+    c1 = {"ndim": 2, "lengthscales": [1.0, 0.5]}
+    c2 = {"nu": 1.5, "ndim": 2, "lengthscales": [1.0, 0.5]}
+    k1 = Matern32Kernel(c1)
+    k2 = MaternKernel(c2)
+    assert (k1.evaluate(x, x) == k2.evaluate(x, x)).all
+
+    # # Matern 5/2
+    c1 = {"ndim": 2, "lengthscales": [1.0, 0.5]}
+    c2 = {"nu": 2.5, "ndim": 2, "lengthscales": [1.0, 0.5]}
+    k1 = Matern52Kernel(c1)
+    k2 = MaternKernel(c2)
+    assert (k1.evaluate(x, x) == k2.evaluate(x, x)).all
+
+    # # Matern 7/2
+    c1 = {"ndim": 2, "lengthscales": [1.0, 0.5]}
+    c2 = {"nu": 3.5, "ndim": 2, "lengthscales": [1.0, 0.5]}
+    k1 = Matern72Kernel(c1)
+    k2 = MaternKernel(c2)
+    assert (k1.evaluate(x, x) == k2.evaluate(x, x)).all

--- a/tests/kernel_embedding_dictionary/kernels/test_matern_kernel.py
+++ b/tests/kernel_embedding_dictionary/kernels/test_matern_kernel.py
@@ -12,6 +12,7 @@ from kernel_embedding_dictionary.kernels import Matern32Kernel, Matern32KernelUn
 from kernel_embedding_dictionary.kernels import Matern52Kernel, Matern52KernelUni
 from kernel_embedding_dictionary.kernels import Matern72Kernel, Matern72KernelUni
 
+
 # tests for MaternKernelUni start here
 def test_matern_kernel_uni_values():
 
@@ -81,7 +82,8 @@ def test_matern_kernel_uni_evaluations():
     # Matern 7/2
     k1 = Matern72KernelUni(ell=ell)
     k2 = MaternNu2KernelUni(nu=3.5, ell=ell)
-    assert (k1.evaluate(x, x) == k2.evaluate(x, x)).all 
+    assert (k1.evaluate(x, x) == k2.evaluate(x, x)).all
+
 
 # tests for MaternKernel start here
 def test_matern_kernel_defaults():
@@ -151,6 +153,7 @@ def test_matern_kernel_raises():
     wrong_c = {"nu": 0.5, "ndim": 1, "lengthscales": [1.0, 1.0]}
     with pytest.raises(ValueError):
         MaternNu2Kernel(wrong_c)
+
 
 def test_matern_kernel_evaluations():
 

--- a/tests/kernel_embedding_dictionary/kernels/test_matern_kernel.py
+++ b/tests/kernel_embedding_dictionary/kernels/test_matern_kernel.py
@@ -86,6 +86,21 @@ def test_matern_kernel_uni_evaluations():
 # tests for MaternKernel start here
 def test_matern_kernel_defaults():
 
+    # nothing given
+    k = MaternNu2Kernel()
+    assert k.ndim == 1
+    assert k.ell == [1.0]
+    assert len(k._kernels) == 1
+    assert k.nu == 2.5
+
+    # only ndim given
+    c = {"ndim": 3}
+    k = MaternNu2Kernel(c)
+    assert k.ndim == 3
+    assert k.ell == [1.0, 1.0, 1.0]
+    assert len(k._kernels) == 3
+    assert k.nu == 2.5
+
     # only nu given
     c = {"nu": 1.5}
     k = MaternNu2Kernel(c)
@@ -100,6 +115,14 @@ def test_matern_kernel_defaults():
     assert k.ndim == 2
     assert k.ell == [1.0, 1.0]
     assert len(k._kernels) == 2
+    assert k.nu == 2.5
+
+    # only ell and ndim given
+    c = {"lengthscales": [1.3, 2.0, 0.5, 0.5], "ndim": 4}
+    k = MaternNu2Kernel(c)
+    assert k.ndim == 4
+    assert k.ell == [1.3, 2.0, 0.5, 0.5]
+    assert len(k._kernels) == 4
     assert k.nu == 2.5
 
     # only ell given

--- a/tests/test_get_embedding.py
+++ b/tests/test_get_embedding.py
@@ -7,11 +7,11 @@ import pytest
 from kernel_embedding_dictionary._get_embedding import get_embedding
 from kernel_embedding_dictionary.kernels import (
     ExpQuadKernel,
-    MaternNu2Kernel,
     Matern12Kernel,
     Matern32Kernel,
     Matern52Kernel,
     Matern72Kernel,
+    MaternNu2Kernel,
 )
 from kernel_embedding_dictionary.measures import GaussianMeasure, LebesgueMeasure
 

--- a/tests/test_get_embedding.py
+++ b/tests/test_get_embedding.py
@@ -7,6 +7,7 @@ import pytest
 from kernel_embedding_dictionary._get_embedding import get_embedding
 from kernel_embedding_dictionary.kernels import (
     ExpQuadKernel,
+    MaternNu2Kernel,
     Matern12Kernel,
     Matern32Kernel,
     Matern52Kernel,
@@ -22,6 +23,7 @@ from kernel_embedding_dictionary.measures import GaussianMeasure, LebesgueMeasur
     [
         ("expquad", ExpQuadKernel, "lebesgue", LebesgueMeasure),
         ("expquad", ExpQuadKernel, "gaussian", GaussianMeasure),
+        ("matern", MaternNu2Kernel, "lebesgue", LebesgueMeasure),
         ("matern12", Matern12Kernel, "lebesgue", LebesgueMeasure),
         ("matern12", Matern12Kernel, "gaussian", GaussianMeasure),
         ("matern32", Matern32Kernel, "lebesgue", LebesgueMeasure),


### PR DESCRIPTION
Added general half-integer Matérns and their embeddings. 

- I think it is useful to retain separate kernels and embeddings for Matérns of orders 1/2, 3/2, 5/2 and 7/2. These are very useful for testing that the general expression for the kernel and its embedding are correct.
- The mean embedding test currently only checks that the embedding obtained from the general half-integer formula agrees with the embeddings from the more explicit formulae for orders 1/2, 3/2, 5/2 and 7/2.
- How I handle dimensions in `matern_lebesgue_mean_func_1d` is probably completely inappropriat.