### PR TITLE
fix: resolve editable install error and license deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-license = {text = "MIT"}
+license = "MIT"
 #license-files = ["LICEN[CS]E*"]
 dependencies = [
     "numpy",
@@ -50,6 +50,13 @@ dev = [
     "coverage>=4.5.1",
     "codecov>=2.0.15",
 ]
+
+################################################################################
+# Package discovery                                                            #
+################################################################################
+
+[tool.setuptools.packages.find]
+include = ["kernel_embedding_dictionary*"]
 
 ################################################################################
 # Formatting                                                     #


### PR DESCRIPTION
  ## Summary

  - Add `[tool.setuptools.packages.find]` with `include = ["kernel_embedding_dictionary*"]` to prevent
    setuptools flat-layout auto-discovery from picking up `venv_kernel_dict/` alongside the actual
    package, which caused the build to fail
  - Update `license = {text = "MIT"}` to `license = "MIT"` (plain SPDX string) to resolve the
    setuptools>=77 deprecation warning

  ## Test plan

  - [ ] Activate venv and run `pip install -e .` — should complete without errors
  - [ ] Verify the package imports correctly: `python -c "import kernel_embedding_dictionary"`