### PR TITLE
fix: bump requires-python to 3.10, expand CI matrix to 3.10-3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 description = "A Python package for kernel embeddings."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",


### PR DESCRIPTION
Python 3.9 reached EOL in October 2025. The minimum is raised to 3.10, which also legitimises the list[...] generic annotation already present in mean_funcs_1d.py. CI now covers all actively supported releases (3.10, 3.11, 3.12, 3.13).