### PR TITLE
docs: clarify dead nu/order params in fixed-order kernel classes and funcs

### DIFF
--- a/kernel_embedding_dictionary/kernels/kernel_funcs_1d.py
+++ b/kernel_embedding_dictionary/kernels/kernel_funcs_1d.py
@@ -25,36 +25,42 @@ def matern_kernel_func_1d(x1: float, x2: float, ell: float, nu: float) -> float:
 
 
 def matern12_kernel_func_1d(x1: float, x2: float, ell: float, nu: float) -> float:
+    # nu is hardcoded in the formula (nu=0.5); accepted to match matern_kernel_func_1d's signature.
     diff = scaled_diff(x1, x2, ell, 1)
     kernel_value = np.exp(-abs(diff))
     return kernel_value
 
 
 def matern32_kernel_func_1d(x1: float, x2: float, ell: float, nu: float) -> float:
+    # nu is hardcoded in the formula (nu=1.5); accepted to match matern_kernel_func_1d's signature.
     abs_diff = np.sqrt(3) * abs(scaled_diff(x1, x2, ell, 1))
     kernel_value = (1 + abs_diff) * np.exp(-abs_diff)
     return kernel_value
 
 
 def matern52_kernel_func_1d(x1: float, x2: float, ell: float, nu: float) -> float:
+    # nu is hardcoded in the formula (nu=2.5); accepted to match matern_kernel_func_1d's signature.
     abs_diff = np.sqrt(5) * abs(scaled_diff(x1, x2, ell, 1))
     kernel_value = (1 + abs_diff + abs_diff**2 / 3) * np.exp(-abs_diff)
     return kernel_value
 
 
 def matern72_kernel_func_1d(x1: float, x2: float, ell: float, nu: float) -> float:
+    # nu is hardcoded in the formula (nu=3.5); accepted to match matern_kernel_func_1d's signature.
     abs_diff = np.sqrt(7) * abs(scaled_diff(x1, x2, ell, 1))
     kernel_value = (1 + abs_diff + 2 * abs_diff**2 / 5 + abs_diff**3 / 15) * np.exp(-abs_diff)
     return kernel_value
 
 
 def wendland0_kernel_func_1d(x1: float, x2: float, ell: float, order: int) -> float:
+    # order is hardcoded in the formula (order=0); accepted to keep the Wendland family signature uniform.
     abs_diff = abs(scaled_diff(x1, x2, ell, 1))
     kernel_value = max(0, (1 - abs_diff))
     return kernel_value
 
 
 def wendland2_kernel_func_1d(x1: float, x2: float, ell: float, order: int) -> float:
+    # order is hardcoded in the formula (order=2); accepted to keep the Wendland family signature uniform.
     abs_diff = abs(scaled_diff(x1, x2, ell, 1))
     kernel_value = max(0, (1 - abs_diff)) ** 3 * (1 + 3 * abs_diff)
     return kernel_value

--- a/kernel_embedding_dictionary/kernels/matern12_kernel.py
+++ b/kernel_embedding_dictionary/kernels/matern12_kernel.py
@@ -15,7 +15,7 @@ class Matern12KernelUni(UnivariateKernel):
             raise ValueError(f"ell ({ell}) must be positive")
 
         self.ell = ell
-        self.nu = 0.5
+        self.nu = 0.5  # defines this kernel variant; not used by the formula but included in param_dict
 
         self._kernel_func = matern12_kernel_func_1d
 

--- a/kernel_embedding_dictionary/kernels/matern32_kernel.py
+++ b/kernel_embedding_dictionary/kernels/matern32_kernel.py
@@ -15,7 +15,7 @@ class Matern32KernelUni(UnivariateKernel):
             raise ValueError(f"ell ({ell}) must be positive")
 
         self.ell = ell
-        self.nu = 1.5
+        self.nu = 1.5  # defines this kernel variant; not used by the formula but included in param_dict
 
         self._kernel_func = matern32_kernel_func_1d
 

--- a/kernel_embedding_dictionary/kernels/matern52_kernel.py
+++ b/kernel_embedding_dictionary/kernels/matern52_kernel.py
@@ -15,7 +15,7 @@ class Matern52KernelUni(UnivariateKernel):
             raise ValueError(f"ell ({ell}) must be positive")
 
         self.ell = ell
-        self.nu = 2.5
+        self.nu = 2.5  # defines this kernel variant; not used by the formula but included in param_dict
 
         self._kernel_func = matern52_kernel_func_1d
 

--- a/kernel_embedding_dictionary/kernels/matern72_kernel.py
+++ b/kernel_embedding_dictionary/kernels/matern72_kernel.py
@@ -15,7 +15,7 @@ class Matern72KernelUni(UnivariateKernel):
             raise ValueError(f"ell ({ell}) must be positive")
 
         self.ell = ell
-        self.nu = 3.5
+        self.nu = 3.5  # defines this kernel variant; not used by the formula but included in param_dict
 
         self._kernel_func = matern72_kernel_func_1d
 

--- a/kernel_embedding_dictionary/kernels/wendland0_kernel.py
+++ b/kernel_embedding_dictionary/kernels/wendland0_kernel.py
@@ -17,7 +17,7 @@ class Wendland0KernelUni(UnivariateKernel):
             raise ValueError(f"ell ({ell}) must be positive")
 
         self.ell = ell
-        self.order = 0
+        self.order = 0  # defines this kernel variant; not used by the formula but included in param_dict
 
         self._kernel_func = wendland0_kernel_func_1d
 

--- a/kernel_embedding_dictionary/kernels/wendland2_kernel.py
+++ b/kernel_embedding_dictionary/kernels/wendland2_kernel.py
@@ -17,7 +17,7 @@ class Wendland2KernelUni(UnivariateKernel):
             raise ValueError(f"ell ({ell}) must be positive")
 
         self.ell = ell
-        self.order = 2
+        self.order = 2  # defines this kernel variant; not used by the formula but included in param_dict
 
         self._kernel_func = wendland2_kernel_func_1d
 


### PR DESCRIPTION
The nu and order parameters are hardcoded in the fixed-order formulas but kept in param_dict and function signatures for interface uniformity with the generic Matern/Wendland counterparts. Comments now make this explicit.

Note by a human: Agents like claude got confused by this dead parameters, so adding a comment for them. 