### PR TITLE
docs: clarify scalar max() in Wendland kernel funcs is intentional

### DIFF
--- a/kernel_embedding_dictionary/kernels/kernel_funcs_1d.py
+++ b/kernel_embedding_dictionary/kernels/kernel_funcs_1d.py
@@ -55,12 +55,12 @@ def matern72_kernel_func_1d(x1: float, x2: float, ell: float, nu: float) -> floa
 def wendland0_kernel_func_1d(x1: float, x2: float, ell: float, order: int) -> float:
     # order is hardcoded in the formula (order=0); accepted to keep the Wendland family signature uniform.
     abs_diff = abs(scaled_diff(x1, x2, ell, 1))
-    kernel_value = max(0, (1 - abs_diff))
+    kernel_value = max(0, (1 - abs_diff))  # scalar max; these funcs are called with float inputs only
     return kernel_value
 
 
 def wendland2_kernel_func_1d(x1: float, x2: float, ell: float, order: int) -> float:
     # order is hardcoded in the formula (order=2); accepted to keep the Wendland family signature uniform.
     abs_diff = abs(scaled_diff(x1, x2, ell, 1))
-    kernel_value = max(0, (1 - abs_diff)) ** 3 * (1 + 3 * abs_diff)
+    kernel_value = max(0, (1 - abs_diff)) ** 3 * (1 + 3 * abs_diff)  # scalar max; these funcs are called with float inputs only
     return kernel_value

--- a/kernel_embedding_dictionary/kernels/kernel_funcs_1d.py
+++ b/kernel_embedding_dictionary/kernels/kernel_funcs_1d.py
@@ -55,12 +55,14 @@ def matern72_kernel_func_1d(x1: float, x2: float, ell: float, nu: float) -> floa
 def wendland0_kernel_func_1d(x1: float, x2: float, ell: float, order: int) -> float:
     # order is hardcoded in the formula (order=0); accepted to keep the Wendland family signature uniform.
     abs_diff = abs(scaled_diff(x1, x2, ell, 1))
-    kernel_value = max(0, (1 - abs_diff))  # scalar max; these funcs are called with float inputs only
+    # scalar max; these funcs are called with float inputs only
+    kernel_value = max(0, (1 - abs_diff))
     return kernel_value
 
 
 def wendland2_kernel_func_1d(x1: float, x2: float, ell: float, order: int) -> float:
     # order is hardcoded in the formula (order=2); accepted to keep the Wendland family signature uniform.
     abs_diff = abs(scaled_diff(x1, x2, ell, 1))
-    kernel_value = max(0, (1 - abs_diff)) ** 3 * (1 + 3 * abs_diff)  # scalar max; these funcs are called with float inputs only
+    # scalar max; these funcs are called with float inputs only
+    kernel_value = max(0, (1 - abs_diff)) ** 3 * (1 + 3 * abs_diff)
     return kernel_value


### PR DESCRIPTION
These _1d functions are only called with float inputs; the comment prevents agents or reviewers from replacing max() with np.maximum() as a false fix.