### PR TITLE
feat: add public kernel and measure properties to KernelEmbedding

### DIFF
--- a/kernel_embedding_dictionary/embeddings/embedding.py
+++ b/kernel_embedding_dictionary/embeddings/embedding.py
@@ -36,6 +36,14 @@ class KernelEmbedding:
         # kernel and measure must be set first
         self._mean_func_1d = self._get_1d_funcs()
 
+    @property
+    def kernel(self) -> ProductKernel:
+        return self._kernel
+
+    @property
+    def measure(self) -> ProductMeasure:
+        return self._measure
+
     def __str__(self) -> str:
         return f"Kernel embedding for\n\n{self._kernel.__str__()}\n\nand\n\n{self._measure.__str__()}"
 

--- a/tests/test_get_embedding.py
+++ b/tests/test_get_embedding.py
@@ -41,8 +41,8 @@ def test_get_embedding_returns_correct_types(embedding):
     k_name, k_type, m_name, m_type = embedding
     ke = get_embedding(k_name, m_name)
 
-    assert isinstance(ke._kernel, k_type)
-    assert isinstance(ke._measure, m_type)
+    assert isinstance(ke.kernel, k_type)
+    assert isinstance(ke.measure, m_type)
 
 
 def test_get_embedding_raises():


### PR DESCRIPTION
Exposes read-only properties so callers and tests don't need to access private _kernel and _measure attributes directly. Addresses #23 partially. 